### PR TITLE
snapcraft.yaml: use "on amd64" to install gcc-arm-linux-gnueabihf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - sudo mount --bind /dev $CHROOT/dev
   - sudo sed -i '/^deb/s/$/ universe/' $CHROOT/etc/apt/sources.list
   - sudo chroot $CHROOT apt update
-  - sudo chroot $CHROOT apt install -y snapcraft gcc-arm-linux-gnueabihf
+  - sudo chroot $CHROOT apt install -y snapcraft
   - find . -mindepth 1 -maxdepth 1 -not -name "$CHROOT" | sudo xargs cp -a --target-dir="$CHROOT/build"
 
 script:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,8 +34,8 @@ parts:
       - device-tree-compiler
       - libpython2.7-dev
       - python-minimal
-      - on amd64 to armhf:
-        - gcc-arm-linux-gnueabihf:amd64
+      - on amd64:
+        - gcc-arm-linux-gnueabihf
   uboot-pi3:
     plugin: nil
     source: git://git.denx.de/u-boot.git
@@ -61,8 +61,8 @@ parts:
       - html2text
       - libpython2.7-dev
       - python-minimal
-      - on amd64 to armhf:
-        - gcc-arm-linux-gnueabihf:amd64
+      - on amd64:
+        - gcc-arm-linux-gnueabihf
   boot-firmware:
     plugin: nil
     source: .


### PR DESCRIPTION
The current snapcraft.yaml is using "on amd64 to armhf" to trigger
the install of the gcc-arm-linux-gnueabihf cross compiler. However
this does not work when building the snap in LP. This is reported
as LP:#1795430 and once this is fixed we can revert this change.

This PR works around this issue by simply using "on amd64" without
the "to armhf". This is fine because the snapcraft.yaml currently
only supports building on amd64 to armhf anyway, no other build
will work.