### PR TITLE
snapcraft.yaml: fix build by pointing to the right linaro toolchain

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -44,7 +44,7 @@ parts:
       git apply ../../../uboot3.patch
       make rpi_3_32b_defconfig
       TCHAINVER="$(wget -q -O - \
-                 https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/| \
+                 https://releases.linaro.org/components/toolchain/binaries/latest-7/arm-linux-gnueabihf/| \
                  html2text -width 200|grep 'x86_64_arm-linux-gnueabihf.tar.xz '|cut -d' ' -f2)"
       wget https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/$TCHAINVER
       tar xf $TCHAINVER


### PR DESCRIPTION
The location of the toolchain on the linaro server has changed

This actually makes me wonder - we install the package gcc-arm-linux-gnueabihf which is version 7.3.0-3ubuntu2.1. We also download the gcc from linaro which is arm-linux-gnueabihf version cc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf.tar.xz. Could we use the ubuntu version? At least the version number seems to be the same (even though the date indicates that linaro pulls in more fixes?).