### PR TITLE
RFC: use ubuntu cross gcc to build uboot

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,13 +43,7 @@ parts:
     override-build: |
       git apply ../../../uboot3.patch
       make rpi_3_32b_defconfig
-      TCHAINVER="$(wget -q -O - \
-                 https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/| \
-                 html2text -width 200|grep 'x86_64_arm-linux-gnueabihf.tar.xz '|cut -d' ' -f2)"
-      wget https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/$TCHAINVER
-      tar xf $TCHAINVER
-      mv $(echo $TCHAINVER|sed 's/.tar.xz$//') toolchain
-      CROSS_COMPILE=$(pwd)/toolchain/bin/arm-linux-gnueabihf- make
+      CROSS_COMPILE=arm-linux-gnueabihf- make
       mkdir -p $SNAPCRAFT_PART_INSTALL/boot-assets
       cp u-boot.bin $SNAPCRAFT_PART_INSTALL/boot-assets/uboot3.bin
     build-packages:


### PR DESCRIPTION
The uboot-pi3 part is currently build using an external linaro gcc.
However in bionic we have the same major version and building with
it seems to still work so I would like to drop the external URL.

This would superseed #8