### PR TITLE
Pull in uboot v2019.04 for pi3.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -38,7 +38,7 @@ parts:
   uboot-pi3:
     plugin: nil
     source: git://git.denx.de/u-boot.git
-    source-tag: v2018.07-rc3
+    source-tag: v2019.04
     override-build: |
       git apply ../../../uboot3.patch
       make rpi_3_32b_defconfig

--- a/uboot3.patch
+++ b/uboot3.patch
@@ -13,7 +13,7 @@ index 9ce41767a9..fbec105a11 100644
 +#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
 +/* Load environment from USB if no SD card */
 +#define CONFIG_PREBOOT			"usb start; if test ! \"mmc dev 0\"; then " \
-+	"fatload usb 0:1 0x3000000 "CONFIG_ENV_FAT_FILE,"; " \
++	"fatload usb 0:1 0x3000000 "CONFIG_ENV_FAT_FILE"; " \
 +	"env import -b 0x3000000; " \
 +	"fi;"
  

--- a/uboot3.patch
+++ b/uboot3.patch
@@ -1,25 +1,29 @@
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 69a22e1..cfe987a 100644
+index 9ce41767a9..fbec105a11 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -73,9 +73,18 @@
+@@ -71,9 +71,14 @@
  #define CONFIG_SYS_CBSIZE		1024
  
  /* Environment */
 -#define CONFIG_ENV_SIZE			SZ_16K
-+#define CONFIG_ENV_SIZE                 SZ_128K
-+#define FAT_ENV_INTERFACE               "mmc"
-+#define FAT_ENV_DEVICE_AND_PART         "0:1"
-+#define FAT_ENV_FILE                    "uboot.env"
-+#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
++#define CONFIG_ENV_SIZE			SZ_128K
  #define CONFIG_SYS_LOAD_ADDR		0x1000000
 -#define CONFIG_PREBOOT			"usb start"
-+
++#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
 +/* Load environment from USB if no SD card */
-+#define CONFIG_PREBOOT                  "usb start; if test ! \"mmc dev 0\"; then " \
-+        "fatload usb 0:1 0x3000000 "FAT_ENV_FILE"; " \
-+        "env import -b 0x3000000; " \
-+        "fi;"
++#define CONFIG_PREBOOT			"usb start; if test ! \"mmc dev 0\"; then " \
++	"fatload usb 0:1 0x3000000 "CONFIG_ENV_FAT_FILE,"; " \
++	"env import -b 0x3000000; " \
++	"fi;"
  
  /* Shell */
  
+@@ -81,6 +86,7 @@
+ #define CONFIG_SETUP_MEMORY_TAGS
+ #define CONFIG_CMDLINE_TAG
+ #define CONFIG_INITRD_TAG
++#define CONFIG_SUPPORT_RAW_INITRD
+ 
+ /* Environment */
+ #define ENV_DEVICE_SETTINGS \


### PR DESCRIPTION
This is mirroring what has been merged in pi3-gadget for the core16 gadgets.