### PR TITLE
Use the same firmware tag as disco & eoan (for CM3+)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,9 @@ summary: Raspberry Pi gadget
 description: |
  Support files for booting Raspberry Pi.
  This gadget snap supports the Pi2, Pi3 and the Compute
- Module 3 devices.
+ Module 3 devices universally.
+ Due to specific compiler requirements it can only be built
+ on amd64 systems (it will automatically build for ARM)
 type: gadget
 base: core18
 architectures:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -63,7 +63,7 @@ parts:
       - uboot-pi2
       - uboot-pi3
     override-build: |
-      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20180919"
+      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20190215"
       mkdir -p $SNAPCRAFT_PART_INSTALL/boot-assets
       for file in fixup start bootcode LICENCE COPYING; do
         cp firmware/boot/${file}* $SNAPCRAFT_PART_INSTALL/boot-assets


### PR DESCRIPTION
The linux-firmware-raspi2 package in classic disco & eoan uses the
February 2019 firmware to enable boot on the Compute Module 3+; core
should use the same tag in the firmware repo.