### PR TITLE
Mirror Dave's changes from the armhf branch: bump the firmware version.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
     after:
       - uboot-pi3
     override-build: |
-      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20180919"
+      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20190215"
       mkdir -p $SNAPCRAFT_PART_INSTALL/boot-assets
       for file in fixup start bootcode LICENCE COPYING; do
         cp firmware/boot/${file}* $SNAPCRAFT_PART_INSTALL/boot-assets


### PR DESCRIPTION
Based on https://github.com/snapcore/pi-gadget/pull/16

Use the same firmware tag as disco & eoan (for CM3+)