### PR TITLE
Use the correct compression format for the psplash initrd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -66,7 +66,7 @@ parts:
       mkdir -p initrd/bin
       cp psplash initrd/bin
       mkdir -p $SNAPCRAFT_PART_INSTALL/boot-assets
-      cd initrd && find . | cpio --quiet -o -H newc | lz4 -9 >> \
+      cd initrd && find . | cpio --quiet -o -H newc | lz4 -9 -l >> \
         "${SNAPCRAFT_PART_INSTALL}/boot-assets/psplash.img"
     build-packages:
       - libgdk-pixbuf2.0-dev


### PR DESCRIPTION
If the legacy format isn't used, the kernel fails to unpack the
auxilliary initrd, and the splash screen doesn't show