### PR TITLE
gadget.yaml: move ubuntu-boot to VFAT

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -14,8 +14,8 @@ volumes:
             target: /
       - name: ubuntu-boot
         role: system-boot
-        filesystem: ext4
-        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        filesystem: vfat
+        type: 0C
         # whats the appropriate size?
         size: 750M
         content:


### PR DESCRIPTION
The uboot bootloader cannot write to ext4 partitions. However we
need to keep state information about the booted kernel on
ubuntu-boot from the bootloader. So we need to switch this
paritition type to vfat.