### PR TITLE
gadget: add placeholder partion for boot select

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -21,6 +21,11 @@ volumes:
         content:
           - source: boot-assets/
             target: /
+      - name: boot-select
+        role: bootselect
+        filesystem: vfat
+        type: 0C
+        size: 5M
       - name: ubuntu-data
         role: system-data
         filesystem: ext4


### PR DESCRIPTION
Raspberry foundation is working on support of boot selection and automatic rollbacks in firmware.
There is possibly going to be additional writable partition used for message passing between firmware and user space
Add placeholder partition, so we can avoid repartitioning later

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>