### PR TITLE
gadget.yaml: install uboot.conf on ubuntu-boot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - sudo apt-get update
 
 script:
-  - sudo snapcraft --destructive-mode
+  - sudo snapcraft --destructive-mode --target-arch=arm64

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -19,8 +19,8 @@ volumes:
         # whats the appropriate size?
         size: 750M
         content:
-          - source: boot-assets/
-            target: /
+          - source: uboot.conf
+            target: boot/uboot/uboot.env
       - name: ubuntu-data
         role: system-data
         filesystem: ext4


### PR DESCRIPTION
The ubuntu-boot partition only needs uboot.env to be a valid bootloader for snapd to find it, it doesn't need all the boot-assets files.