### PR TITLE
Extend arches

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,9 +7,6 @@ description: |
  Module 3, and the Compute Module 3+ universally.
 type: gadget
 base: core20
-architectures:
-  - build-on: [amd64, arm64, armhf]
-    run-on: [arm64, armhf]
 confinement: strict
 grade: stable
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,8 +8,8 @@ description: |
 type: gadget
 base: core20
 architectures:
-  - build-on: [amd64, arm64]
-    run-on: arm64
+  - build-on: [amd64, arm64, armhf]
+    run-on: [arm64, armhf]
 confinement: strict
 grade: stable
 parts:


### PR DESCRIPTION
This makes the 20 gadget universal. It seems like launchpad is able to build it on arm64 for arm64, and build it on armhf for armhf. So i'm not sure why 18 branches are separate for armhf & arm64.

So I created 20 branch, just like the pc uefi gadget, and proposing this there. Then will build both arm64 & armhf from the 20 branch of the pi gadget.