### PR TITLE
gadget.yaml: install uboot.conf onto boot.sel on ubuntu-boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ config-core: $(DESTDIR)/boot-assets
 	#            of the partition and instead the boot.scr is used. this may 
 	#            change for the final release
 	touch $(DESTDIR)/uboot.conf
+	# the boot.sel file is currently installed onto ubuntu-boot from the gadget
+	# but that will probably change soon so that snapd installs it instead
+	# it is empty now, but snapd will write vars to it
+	mkenvimage -r -s 4096 -o $(DESTDIR)/boot.sel - < /dev/null
 	cp -a configs/core/config.txt.$(ARCH) $(DESTDIR)/boot-assets/config.txt
 	cp -a configs/core/cmdline.txt $(DESTDIR)/boot-assets/cmdline.txt
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,11 @@ boot-script: device-trees $(DESTDIR)/boot-assets
 		-d $(STAGEDIR)/bootscr.rpi $(DESTDIR)/boot-assets/boot.scr
 
 config-core: $(DESTDIR)/boot-assets
-	mkenvimage -r -s 131072 -o $(DESTDIR)/uboot.conf - < /dev/null
+	# TODO:UC20: currently we use an empty uboot.conf as a landmark for the new
+	#            uboot style where there is no uboot.env installed onto the root
+	#            of the partition and instead the boot.scr is used. this may 
+	#            change for the final release
+	touch $(DESTDIR)/uboot.conf
 	cp -a configs/core/config.txt.$(ARCH) $(DESTDIR)/boot-assets/config.txt
 	cp -a configs/core/cmdline.txt $(DESTDIR)/boot-assets/cmdline.txt
 

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -19,8 +19,10 @@ volumes:
         # whats the appropriate size?
         size: 750M
         content:
+          # TODO:UC20: install the boot.sel via snapd instead of via the gadget
+          # also note that this relies on uboot.conf being empty
           - source: uboot.conf
-            target: boot/uboot/uboot.env
+            target: uboot/ubuntu/boot.sel
       - name: ubuntu-data
         role: system-data
         filesystem: ext4

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -20,8 +20,7 @@ volumes:
         size: 750M
         content:
           # TODO:UC20: install the boot.sel via snapd instead of via the gadget
-          # also note that this relies on uboot.conf being empty
-          - source: uboot.conf
+          - source: boot.sel
             target: uboot/ubuntu/boot.sel
       - name: ubuntu-data
         role: system-data


### PR DESCRIPTION
This is likely temporary, but is currently necessary in order to boot.

Also, uboot.conf must be empty for snapd to correctly identify the gadget as not using uboot.env anymore.