### PR TITLE
snapcraft.yaml: also prime boot.sel

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -27,6 +27,7 @@ parts:
     prime:
       - boot-assets/*
       - uboot.conf
+      - boot.sel
     build-packages:
       - u-boot-tools
       - lsb-release


### PR DESCRIPTION
Otherwise packing the snap fails because snap prepare-image can't find boot.sel to verify the gadget.

This bug was introduced with https://github.com/snapcore/pi-gadget/commit/2e494b0720d3f3e376dfa6fd824dcf05136e1600