### PR TITLE
20-armhf: Fix armhf native build detection.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,7 +16,7 @@ parts:
   gadget:
     plugin: nil
     override-build: |
-      if [ "$(arch)" != "aarch64" -a "$(arch)" != "arm7l" ]; then
+      if [ "$(arch)" != "aarch64" -a "$(arch)" != "armv7l" ]; then
         echo "Cross compilation detected; using pre-defined sources list"
         OPTIONAL_ARGS="SOURCES_HOST=\"./helpers/sources.list.cross\""
       fi


### PR DESCRIPTION
Due to this typo the build did "Cross compilation detected; using pre-defined sources list" completely re-wrote the archive sources it was building in, and fetched wrong things. Also cross-building is broken at the moment.