### PR TITLE
Disable LED customization; tidy up config.txt

### DIFF
--- a/configs/core/config.txt.arm64
+++ b/configs/core/config.txt.arm64
@@ -10,11 +10,22 @@ kernel=uboot_rpi_3.bin
 
 [all]
 arm_64bit=1
-enable_uart=1
-dtparam=i2c=on
-dtparam=spi=on
-dtparam=act_led_trigger=heartbeat
-dtparam=pwr_led_trigger=mmc0
-dtparam=audio=on
 device_tree_address=0x02000000
+
+# Enable the serial pins
+enable_uart=1
+
+# Enable the FKMS ("Fake" KMS) graphics overlay, and allocate 128Mb to the
+# GPU memory
 dtoverlay=vc4-fkms-v3d,cma-128
+
+# Enable audio output, I2C and SPI interfaces on the GPIO header
+dtparam=audio=on
+dtparam=i2c_arm=on
+dtparam=spi=on
+
+# Prior versions of Ubuntu Core customized the on-board LEDs so that the green
+# ACT LED was a heartbeat, and the red PWR LED represented SD card activity.
+# Uncomment the following lines if you wish to restore these customizations
+#dtparam=act_led_trigger=heartbeat
+#dtparam=pwr_led_trigger=mmc0

--- a/configs/core/config.txt.armhf
+++ b/configs/core/config.txt.armhf
@@ -9,11 +9,22 @@ kernel=uboot_rpi_2.bin
 kernel=uboot_rpi_3_32b.bin
 
 [all]
-enable_uart=1
-dtparam=i2c=on
-dtparam=spi=on
-dtparam=act_led_trigger=heartbeat
-dtparam=pwr_led_trigger=mmc0
-dtparam=audio=on
 device_tree_address=0x02000000
+
+# Enable the serial pins
+enable_uart=1
+
+# Enable the FKMS ("Fake" KMS) graphics overlay, and allocate 128Mb to the
+# GPU memory
 dtoverlay=vc4-fkms-v3d,cma-128
+
+# Enable audio output, I2C and SPI interfaces on the GPIO header
+dtparam=audio=on
+dtparam=i2c_arm=on
+dtparam=spi=on
+
+# Prior versions of Ubuntu Core customized the on-board LEDs so that the green
+# ACT LED was a heartbeat, and the red PWR LED represented SD card activity.
+# Uncomment the following lines if you wish to restore these customizations
+#dtparam=act_led_trigger=heartbeat
+#dtparam=pwr_led_trigger=mmc0


### PR DESCRIPTION
Prior versions of Core customized the ACT & PWR LEDs. This commit
disables those customizations but leaves a comment to trivially
re-enable them if users should desire. It also adds some commentary to
the other settings in a similar style to that used in the classic
config.txt.

Once merged, this should be cherry-picked to 20-armhf (and possibly
classic & desktop, though only to minimize the branch diffs).

Signed-off-by: Dave Jones <dave.jones@canonical.com>