### PR TITLE
Use dwc2 on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,7 @@ config-core: $(DESTDIR)/boot-assets
 
 config-classic: $(DESTDIR)/boot-assets
 	cp -a configs/classic/*.txt $(DESTDIR)/boot-assets/
-	if [ "$(ARCH)" = "arm64" ]; then \
-		sed -i -e '/^kernel=/ i arm_64bit=1' $(DESTDIR)/boot-assets/config.txt; \
-	fi
+	cat configs/classic/config.txt-$(ARCH) >> $(DESTDIR)/boot-assets/config.txt
 	cp -a configs/classic/user-data $(DESTDIR)/boot-assets/
 	cp -a configs/classic/meta-data $(DESTDIR)/boot-assets/
 	cp -a configs/classic/network-config $(DESTDIR)/boot-assets/

--- a/configs/classic/config.txt-arm64
+++ b/configs/classic/config.txt-arm64
@@ -1,3 +1,4 @@
 
 # Config settings specific to arm64
 arm_64bit=1
+dtoverlay=dwc2

--- a/configs/classic/config.txt-arm64
+++ b/configs/classic/config.txt-arm64
@@ -1,0 +1,3 @@
+
+# Config settings specific to arm64
+arm_64bit=1


### PR DESCRIPTION
We currently use the dwc_otg driver from raspberrypi on both armhf and arm64 kernels. That driver supports FIQ interrupt handling (presumable for better performance) but lacks the maintenance and bug fixing of the vanilla upstream dwc2 driver. Turns out that FIQ handling is disabled in the dwc_otg driver on arm64 so it makes little sense to use that driver on arm64.

In fact, upstream raspberrypi recommends to use the dwc2 driver on arm64.

See: https://bugs.launchpad.net/bugs/1900665
