### PR TITLE
Switch gadget to use new `$kernel:ref` dtb handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ define stage_package
 	dpkg-deb --extract $$(ls $(STAGEDIR)/tmp/$(1)*.deb | tail -1) $(STAGEDIR)
 endef
 
+# XXX: move classic to use new "$kernel:ref" syntax too and remove the "device-trees" rule
+classic: firmware uboot device-trees boot-script config-classic no-kernel-refs-gadget
 
-classic: firmware uboot boot-script config-classic device-trees gadget
-
-core: firmware uboot boot-script config-core device-trees gadget
+core: firmware uboot boot-script config-core gadget
 
 firmware: multiverse $(DESTDIR)/boot-assets
 	# XXX: This deliberately does NOT use $(KERNEL_FLAVOR); not until we've
@@ -88,7 +88,7 @@ uboot: $(DESTDIR)/boot-assets
 			$(DESTDIR)/boot-assets/uboot_$${platform_path##*/}.bin; \
 	done
 
-boot-script: device-trees $(DESTDIR)/boot-assets
+boot-script: $(DESTDIR)/boot-assets
 	$(call stage_package,flash-kernel)
 	# NOTE: the bootscr.rpi* below is deliberate; older flash-kernels have
 	# separate bootscr.rpi? files for different pis, while newer have a
@@ -134,6 +134,13 @@ device-trees: $(DESTDIR)/boot-assets
 	mkdir -p $(DESTDIR)/boot-assets/overlays
 	cp -a $$(find $(STAGEDIR)/lib/firmware/*/device-tree -name "*.dtbo") \
 		$(DESTDIR)/boot-assets/overlays/
+
+# ubuntu-image on classic does not understand the "$kernel:ref" syntax
+# yet and will most likely only do so once it is ported to golang. Use
+# the old syntax for now
+no-kernel-refs-gadget: gadget.yaml
+	mkdir -p $(DESTDIR)/meta
+	sed -e '/source: $kernel:/,+1d' gadget.yaml > $(DESTDIR)/meta/gadget.yaml
 
 gadget:
 	mkdir -p $(DESTDIR)/meta

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ device-trees: $(DESTDIR)/boot-assets
 # the old syntax for now
 no-kernel-refs-gadget: gadget.yaml
 	mkdir -p $(DESTDIR)/meta
-	sed -e '/source: $kernel:/,+1d' gadget.yaml > $(DESTDIR)/meta/gadget.yaml
+	sed -e '/source: $$kernel:/,+1d' gadget.yaml > $(DESTDIR)/meta/gadget.yaml
 
 gadget:
 	mkdir -p $(DESTDIR)/meta

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -1,4 +1,3 @@
-device-tree: bcm2709-rpi-3-b-plus
 volumes:
   pi:
     schema: mbr
@@ -10,6 +9,10 @@ volumes:
         type: 0C
         size: 1200M
         content:
+          - source: $kernel:pidtbs/dtbs/broadcom/
+            target: /
+          - source: $kernel:pidtbs/dtbs/overlays/
+            target: /overlays
           - source: boot-assets/
             target: /
       - name: ubuntu-boot

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Module 3, and the Compute Module 3+ universally.
 type: gadget
 base: core20
+assumes: [kernel-assets]
 architectures:
   - build-on: [amd64, arm64]
     run-on: arm64


### PR DESCRIPTION
Snapd is in the process of supporting DTBs coming from the kernel
snap. This requires an update of the gadget.yaml to point to the
kernel snap for boot assets of the form `$kernel:ref`.

The coresponding kernel snap change requires adding a file
meta/kernel.yaml with the content:
```
assets:
  pidtbs:
    update: true
    content:
    - dtbs/broadcom/
    - dtbs/overlays/
```

This can only land for real once snapd is fully ready, the last
PR that needs to land is https://github.com/snapcore/snapd/pull/9999

Note that this PR also tweaks the "classic" target as well but I did
not test this, because I don't know how it's called. For classic
the new syntax cannot be used because ubuntu-image needs help from
`snap prepare-image` to do the resolving of the content. But the
new `no-kernel-refs-gadget` in the makefile should ensure things
work like before for classic images.

A similar change for armhf will also be needed.

Having a build of this in a branch of the pi gadget would be great, e.g.
20/edge/dtb