### PR TITLE
Backport dtb kernel-assets changes to the UC18 branches.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ define stage_package
 	dpkg-deb --extract $$(ls $(STAGEDIR)/tmp/$(1)*.deb | tail -1) $(STAGEDIR)
 endef
 
+# XXX: move classic to use new "$kernel:ref" syntax too and remove the "device-trees" rule
+classic: firmware uboot device-trees boot-classic no-kernel-refs-gadget
 
-classic: firmware uboot boot-classic device-trees gadget
-
-core: firmware uboot boot-core device-trees gadget
+core: firmware uboot boot-core gadget
 
 firmware: multiverse $(DESTDIR)/boot-assets
 	# XXX: This deliberately does NOT use $(KERNEL_FLAVOR); not until we've
@@ -116,6 +116,13 @@ device-trees: $(DESTDIR)/boot-assets
 	mkdir -p $(DESTDIR)/boot-assets/overlays
 	cp -a $$(find $(STAGEDIR)/lib/firmware/*/device-tree -name "*.dtbo") \
 		$(DESTDIR)/boot-assets/overlays/
+
+# ubuntu-image on classic does not understand the "$kernel:ref" syntax
+# yet and will most likely only do so once it is ported to golang. Use
+# the old syntax for now
+no-kernel-refs-gadget: gadget.yaml
+	mkdir -p $(DESTDIR)/meta
+	sed -e '/source: $$kernel:/,+1d' gadget.yaml > $(DESTDIR)/meta/gadget.yaml
 
 gadget:
 	mkdir -p $(DESTDIR)/meta

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -9,5 +9,9 @@ volumes:
         filesystem-label: system-boot
         size: 256M
         content:
+          - source: $kernel:dtbs/dtbs/broadcom/
+            target: /
+          - source: $kernel:dtbs/dtbs/overlays/
+            target: /overlays
           - source: boot-assets/
             target: /

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
  Module 3, and the Compute Module 3+ universally.
 type: gadget
 base: core18
+assumes: [kernel-assets]
 architectures:
   - build-on: [amd64, arm64]
     run-on: arm64


### PR DESCRIPTION
Backporting the necessary DTB changes from #66 for UC18 gadgets (see original PR for more info).