### PR TITLE
.travis.yml: drop the package repositories experimental flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ addons:
   snaps:
     - name: snapcraft
       confinement: classic
+      # TODO: switch to stable when 4.8 hits stable
+      channel: candidate
     - name: lxd
 env:
   global:
@@ -22,5 +24,4 @@ install:
   - sudo usermod --append --groups lxd $USER
 
 script:
-  # TODO: when package-repositories is not experimental drop this flag
-  - sg lxd 'snapcraft --enable-experimental-package-repositories'
+  - sg lxd snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ addons:
   snaps:
     - name: snapcraft
       confinement: classic
-      # TODO: switch to stable when 4.8 hits stable
-      channel: candidate
     - name: lxd
 env:
   global:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,18 +12,14 @@ architectures:
   - build-on: [amd64, arm64]
     run-on: arm64
 
+package-repositories:
+  - type: apt
+    ppa: snappy-dev/image
+
 confinement: strict
 grade: stable
 parts:
-  add-ppa:
-    plugin: nil
-    build-packages:
-      - software-properties-common
-    override-pull: |
-      sudo add-apt-repository --yes ppa:snappy-dev/image
-      sudo apt update
   gadget:
-    after: [add-ppa]
     plugin: nil
     source: .
     override-build: |
@@ -47,7 +43,6 @@ parts:
       - dpkg-dev
       - make
   psplash-local:
-    after: [add-ppa]
     plugin: dump
     prime: [-*]
     source: .


### PR DESCRIPTION
As of snapcraft 4.8 this flag is no longer necessary.

Also build with candidate snapcraft for this until it hits stable.

Opening as a draft until snapcraft 4.8 actually hits candidate, which I'm told tomorrow is the target for.