### PR TITLE
Fix builds using proper image PPA and without proposed

### DIFF
--- a/helpers/cross-sources.list
+++ b/helpers/cross-sources.list
@@ -4,8 +4,8 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main 
 deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main universe multiverse restricted
 deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main universe multiverse restricted
 deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main universe multiverse restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-proposed main universe multiverse restricted
-deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-proposed main universe multiverse restricted
+#deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-proposed main universe multiverse restricted
+#deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-proposed main universe multiverse restricted
 
 # snappy-dev image PPA
 deb [arch=armhf,arm64] http://ppa.launchpad.net/snappy-dev/image/ubuntu focal main

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,8 +31,12 @@ parts:
       # unconditionally set the arch-triplet since this snapcraft.yaml will 
       # always be used to produce an armhf snap
       BUILD_ARCH_TRIPLET=aarch64-linux-gnu
-
-      OPTIONAL_ARGS="SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
+      # but only use the cross-compiling sources when actually cross compiling
+      # as otherwise its just safer to use the build environment - it offers
+      # much more flexibility.
+      if [ "$SNAPCRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ] || [ -z "$SNAPCRAFT_ARCH_TRIPLET" ]; then
+        OPTIONAL_ARGS="SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
+      fi
       make -C $SNAPCRAFT_PART_SRC core \
         DESTDIR=${SNAPCRAFT_PART_INSTALL} \
         ARCH="$(dpkg-architecture -t $BUILD_ARCH_TRIPLET -q DEB_HOST_ARCH)" \


### PR DESCRIPTION
Disable -proposed in the cross sources (what were those doing there?!), only use cross-sources when actually cross-compiling.

This is terrible but it looks like we've been building the pi UC20 gadget with -proposed enabled since day 1! This is not good. We should not build with proposed anything that can potentially end up with users.