### PR TITLE
Fix apt usage and improve classic docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SOURCES_RESTRICTED := "$(STAGEDIR)/apt/restricted.sources.list"
 #
 define stage_package
 	mkdir -p $(STAGEDIR)/tmp
+	touch $(STAGEDIR)/tmp/status
 	( \
 		cd $(STAGEDIR)/tmp && \
 		apt-get download \
@@ -36,6 +37,7 @@ define stage_package
 				apt-cache \
 					-o APT::Architecture=$(ARCH) \
 					-o Dir::Etc::sourcelist=$(SOURCES_RESTRICTED) \
+					-o Dir::State::status=$(STAGEDIR)/tmp/status \
 					showpkg $(1) | \
 					sed -n -e 's/^Package: *//p' | \
 					sort -V | tail -1 \

--- a/README.md
+++ b/README.md
@@ -1,22 +1,17 @@
 # Raspberry Pi "Universal" Gadget Snap
 
-This repository contains the source for an Ubuntu Core gadget snap that runs
+This repository contains the source for an Ubuntu Classic gadget snap that runs
 universally on all Raspberry Pi 3 boards currently supported by Ubuntu Core
-(the Raspberry Pi 2B, 3B, 3A+, 3B+, 4B, Compute Module 3, and Compute Module
-3+).
+(the Raspberry Pi 2B, 3B, 3A+, 3B+, 4B, 400, Compute Module 3, Compute Module
+3+, and Compute Module 4).
 
-Building it with snapcraft will obtain various components from the
-bionic-updates archive, including:
+Building it with make will obtain various components from the archive,
+including:
 
 * the bootloader firmware from the linux-firmware-raspi2 package
 * the device-tree(s) from the linux-modules-<ver>-raspi2 package
 * u-boot binaries (for various models) from the u-boot-rpi package
 * u-boot boot script from the flash-kernel package (classic gadgets only)
-
-On core builds, a silent boot with a splash screen is included. The splash
-screen binary comes from git://git.yoctoproject.org/psplash. Please see the
-`psplash/` sub directory for patches and adjustments in use.
-
 
 ## Gadget Snaps
 
@@ -31,33 +26,11 @@ Please report all issues here on the github page via:
 https://github.com/snapcore/pi-gadget/issues
 
 
-## Branding
-
-This gadget snap comes with a boot splash. To change the logo you can add a new
-png file to the psplash subdirectory of this tree, adjust the "SPLASH=" option
-in `psplash/config` to point to this file and rebuild the gadget.
-
-To turn off the splash screen completely please edit `configs/core/cmdline.txt`
-and remove the `splash` and the `vt.handoff=2` keywords from the default kernel
-commandline.
-
-
 ## Building
 
-This gadget snap can optionally be cross built on an amd64 machine. To do so,
-just run `snapcraft` with an appropriate `--target-arch` switch, and
-`--destructive-mode` in the top level of the source tree after cloning it and
-selecting the appropriate branch:
+Building natively on an armhf or arm64 system is as simple as running
+`sudo SERIES=<series> make`. For example, `sudo SERIES=jammy make`.
 
-    $ sudo snap install snapcraft --classic
-    $ git clone https://github.com/snapcore/pi-gadget
-    $ cd pi-gadget
-    $ git checkout 18-arm64
-    $ sudo snapcraft clean --destructive-mode
-    $ sudo snapcraft snap --target-arch=arm64 --destructive-mode
-
-The branches included are:
-
-* 18-arm64 - the branch for Core 18 on arm64
-* 18-armhf - the branch for Core 18 on armhf
-* classic - the branch for Ubuntu (universal gadget)
+This gadget snap can optionally be cross built on an amd64 machine.
+Just add the environment variable `ARCH` to the make command. For
+example, `sudo SERIES=jammy ARCH=arm64 make`.


### PR DESCRIPTION
This addresses two things:

If the package version in /var/lib/dpkg/status was newer than what is available on the target SERIES, errors would occur. Using -o Dir::State::status=<empty_file> avoids that and only considers versions present in the apt sources list.

Docs for classic were pretty outdated. We need to use make to prime the gadget snap rather than classic, and the psplash stuff doesn't actually seem to apply to classic images.

I know it's generally thought of as not-best-practice to have a different README per branch, but that's because branches are meant to be ephemeral in most cases. Since this classic branch is meant to stay around, I think it makes sense to have a separate README.