### PR TITLE
Add slot for /dev/ttyS0 and add pi0 section to config.txt

### DIFF
--- a/configs/core/config.txt.arm64
+++ b/configs/core/config.txt.arm64
@@ -8,6 +8,9 @@ kernel=uboot_rpi_2.bin
 [pi3]
 kernel=uboot_rpi_3.bin
 
+[pi0]
+kernel=uboot_rpi_3.bin
+
 [all]
 arm_64bit=1
 device_tree_address=0x02000000

--- a/configs/core/config.txt.armhf
+++ b/configs/core/config.txt.armhf
@@ -8,6 +8,9 @@ kernel=uboot_rpi_2.bin
 [pi3]
 kernel=uboot_rpi_3_32b.bin
 
+[pi0]
+kernel=uboot_rpi_3.bin
+
 [all]
 device_tree_address=0x02000000
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -212,9 +212,44 @@ slots:
   serial0:
     interface: serial-port
     path: /dev/ttyS0
+  serial1:
+    interface: serial-port
+    path: /dev/ttyS1
+  serial2:
+    interface: serial-port
+    path: /dev/ttyS2
+  serial3:
+    interface: serial-port
+    path: /dev/ttyS3
+  serial4:
+    interface: serial-port
+    path: /dev/ttyS4
+  serial5:
+    interface: serial-port
+    path: /dev/ttyS5
+  serial6:
+    interface: serial-port
+    path: /dev/ttyS6
+  serial7:
+    interface: serial-port
+    path: /dev/ttyS7
+  serial8:
+    interface: serial-port
+    path: /dev/ttyS8
+  serial9:
+    interface: serial-port
+    path: /dev/ttyS9
   spidev0:
     interface: spi
     path: /dev/spidev0.0
   spidev1:
     interface: spi
     path: /dev/spidev0.1
+  pwm0:
+    interface: pwm
+    chip-number: 0
+    channel: 0
+  pwm1:
+    interface: pwm
+    chip-number: 0
+    channel: 1

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -209,6 +209,9 @@ slots:
   bt-serial:
     interface: serial-port
     path: /dev/ttyAMA0
+  serial0:
+    interface: serial-port
+    path: /dev/ttyS0
   spidev0:
     interface: spi
     path: /dev/spidev0.0


### PR DESCRIPTION
Some hats use /dev/ttyS0. It should be safe to include in the gadget, and then can be connected to a snap with the `snap connect` command.