### PR TITLE
Add i2c-3 through i2c-6 for Raspberry Pi 4

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -206,6 +206,18 @@ slots:
   i2c-2:
     interface: i2c
     path: /dev/i2c-2
+  i2c-3:
+    interface: i2c
+    path: /dev/i2c-3
+  i2c-4:
+    interface: i2c
+    path: /dev/i2c-4
+  i2c-5:
+    interface: i2c
+    path: /dev/i2c-5
+  i2c-6:
+    interface: i2c
+    path: /dev/i2c-6
   bt-serial:
     interface: serial-port
     path: /dev/ttyAMA0


### PR DESCRIPTION
These I2C busses are available on Raspberry Pi 4, eg:


```
dtparam=i2c_arm=on,i2c_arm_baudrate=400000
dtoverlay=i2c3,pins_4_5,baudrate=400000
dtoverlay=i2c4,pins_6_7,baudrate=400000
dtoverlay=i2c5,pins_10_11,baudrate=400000
dtoverlay=i2c6,pins_22_23,baudrate=400000
```
See Issue #48