### PR TITLE
Switch to using directly piboot instead of u-boot

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -1,7 +1,7 @@
 volumes:
   pi:
     schema: mbr
-    bootloader: u-boot
+    bootloader: piboot
     structure:
       - name: ubuntu-seed
         role: system-seed
@@ -15,16 +15,16 @@ volumes:
             target: /overlays
           - source: boot-assets/
             target: /
+          - source: cmdline.txt
+            target: /
+          - source: config.txt
+            target: /
       - name: ubuntu-boot
         role: system-boot
         filesystem: vfat
         type: 0C
         # whats the appropriate size?
         size: 750M
-        content:
-          # TODO:UC20: install the boot.sel via snapd instead of via the gadget
-          - source: boot.sel
-            target: uboot/ubuntu/boot.sel
       # NOTE: ubuntu-save is optional for unencrypted devices like the pi, so
       # this structure can be dropped in favor of a different partition for
       # users who wish to instead use a different partition, since with MBR we

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
       # as otherwise its just safer to use the build environment - it offers
       # much more flexibility.
       if [ "$SNAPCRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ] || [ -z "$SNAPCRAFT_ARCH_TRIPLET" ]; then
-        OPTIONAL_ARGS="SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
+        OPTIONAL_ARGS="SERIES_HOST=\"focal\" SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
       fi
       make -C $SNAPCRAFT_PART_SRC core \
         DESTDIR=${SNAPCRAFT_PART_INSTALL} \
@@ -39,10 +39,10 @@ parts:
         ${OPTIONAL_ARGS:-}
     prime:
       - boot-assets/*
-      - uboot.conf
-      - boot.sel
+      - piboot.conf
+      - cmdline.txt
+      - config.txt
     build-packages:
-      - u-boot-tools
       - lsb-release
       - dpkg-dev
       - make


### PR DESCRIPTION
Use piboot directly instead of running u-boot as second stage
bootloader, now that is supported by snapd.

Opening as a draft, just as reference for the moment. We might maybe want this a separate branch in this repository (`22-arm64-piboot`?)

These other PRs would be needed:
https://github.com/snapcore/snapd/pull/11068
https://github.com/canonical/ubuntu-image/pull/40
https://github.com/snapcore/core-base/pull/30
https://github.com/snapcore/core-initrd/pull/85