### PR TITLE
Increase boot partition size to accommodate compression changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ ifeq ($(ARCH),arm64)
 MKIMAGE_ARCH := arm64
 else ifeq ($(ARCH),armhf)
 MKIMAGE_ARCH := arm
-else
-$(error Build architecture is not supported)
 endif
 
 # Some trivial comparator macros; please note that these are very simplistic
@@ -85,9 +83,9 @@ endef
 
 default: server
 
-server: firmware uboot boot-script config-server device-trees gadget kernel initrd
+server: firmware uboot boot-script config-server device-trees gadget
 
-desktop: firmware uboot boot-script config-desktop device-trees gadget kernel initrd
+desktop: firmware uboot boot-script config-desktop device-trees gadget
 
 core: firmware uboot boot-script config-core device-trees gadget
 
@@ -97,13 +95,6 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 		cp -a $(STAGEDIR)/usr/lib/linux-firmware-$(FIRMWARE_FLAVOR)/$${file}* \
 			$(DESTDIR)/boot-assets/; \
 	done
-
-kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
-	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
-
-initrd:
-	mkinitramfs -o $(DESTDIR)/boot-assets/initrd.img
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/Makefile
+++ b/Makefile
@@ -221,16 +221,10 @@ device-trees: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 		$(DESTDIR)/boot-assets/overlays/
 
 kernel-initrd:
-	# Add lines to gadget.yaml to handle copying the kernel and initrd
-	echo  "\
-          - source: rootfs:/boot/vmlinuz\n\
-            target: /\n\
-          - source: rootfs:/boot/vmlinuz-$(KERNEL_VERSION)\n\
-            target: /\n\
-          - source: rootfs:/boot/initrd.img\n\
-            target: /\n\
-          - source: rootfs:/boot/initrd.img-$(KERNEL_VERSION)\n\
-            target: /" >> gadget.yaml
+	# Update the kernel version in extra_content.yaml
+	sed \
+		-e "s/@@KERNEL_VERSION@@/$(KERNEL_VERSION)/g" \
+		extra_content.yaml >> gadget.yaml
 
 gadget:
 	mkdir -p $(DESTDIR)/meta

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
 
 initrd:
 	mkinitramfs -o $(DESTDIR)/boot-assets/initrd.img

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ endef
 
 default: server
 
-server: firmware uboot boot-script config-server device-trees gadget kernel
+server: firmware uboot boot-script config-server device-trees gadget kernel initrd
 
-desktop: firmware uboot boot-script config-desktop device-trees gadget kernel
+desktop: firmware uboot boot-script config-desktop device-trees gadget kernel initrd
 
 core: firmware uboot boot-script config-core device-trees gadget
 
@@ -100,7 +100,10 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
+
+initrd:
+	mkinitramfs -o $(DESTDIR)/boot-assets/initrd.img
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ endef
 
 default: server
 
-server: firmware uboot boot-script config-server device-trees gadget
+server: firmware uboot boot-script config-server device-trees gadget kernel
 
-desktop: firmware uboot boot-script config-desktop device-trees gadget
+desktop: firmware uboot boot-script config-desktop device-trees gadget kernel
 
 core: firmware uboot boot-script config-core device-trees gadget
 
@@ -97,6 +97,10 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 		cp -a $(STAGEDIR)/usr/lib/linux-firmware-$(FIRMWARE_FLAVOR)/$${file}* \
 			$(DESTDIR)/boot-assets/; \
 	done
+
+kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
+	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/extra_content.yaml
+++ b/extra_content.yaml
@@ -1,0 +1,8 @@
+          - source: rootfs:/boot/vmlinuz
+            target: /
+          - source: rootfs:/boot/vmlinuz-@@KERNEL_VERSION@@
+            target: /
+          - source: rootfs:/boot/initrd.img
+            target: /
+          - source: rootfs:/boot/initrd.img-@@KERNEL_VERSION@@
+            target: /

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -11,7 +11,3 @@ volumes:
         content:
           - source: install/boot-assets/
             target: /
-          - source: rootfs:/boot/vmlinuz*
-            target: vmlinuz
-          - source: rootfs:/boot/initrd*
-            target: initrd.img

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -9,5 +9,5 @@ volumes:
         filesystem-label: system-boot
         size: 512M
         content:
-          - source: boot-assets/
+          - source: install/boot-assets/
             target: /

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -7,7 +7,7 @@ volumes:
       - type: 0C
         filesystem: vfat
         filesystem-label: system-boot
-        size: 384M
+        size: 512M
         content:
           - source: boot-assets/
             target: /

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -7,7 +7,7 @@ volumes:
       - type: 0C
         filesystem: vfat
         filesystem-label: system-boot
-        size: 256M
+        size: 384M
         content:
           - source: boot-assets/
             target: /

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -11,3 +11,7 @@ volumes:
         content:
           - source: install/boot-assets/
             target: /
+          - source: rootfs:/boot/vmlinuz
+            target: vmlinuz
+          - source: rootfs:/boot/initrd.img
+            target: initrd.img

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -11,7 +11,7 @@ volumes:
         content:
           - source: install/boot-assets/
             target: /
-          - source: rootfs:/boot/vmlinuz
+          - source: rootfs:/boot/vmlinuz*
             target: vmlinuz
-          - source: rootfs:/boot/initrd.img
+          - source: rootfs:/boot/initrd*
             target: initrd.img


### PR DESCRIPTION
We had a discussion today about leaving space for organic growth of the initrd and the fact that changing compression sizes has led to larger initrd images.