### PR TITLE
Build with linux-firmware-raspi from a PPA temporarily.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 # to this (focal and before) certain bits were (are) in universe or multiverse
 RESTRICTED_COMPONENT := $(if $(call le,$(SERIES_RELEASE),20.04),universe multiverse,restricted)
 $(SOURCES_RESTRICTED):
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv C176CB99A28EA6D8 # TODO: remove this
 	mkdir -p $(STAGEDIR)/apt
 	mkdir -p $(STAGEDIR)/tmp
 	touch $(STAGEDIR)/tmp/status

--- a/sources.list
+++ b/sources.list
@@ -2,5 +2,5 @@ deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES main restricted
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-updates main restricted
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-security main restricted
 deb [arch=ARCH] http://ppa.launchpad.net/jawn-smith/linux-firmware-raspi/ubuntu SERIES main
-# TODO: remove the PPA
+# TODO: remove the PPA above. It is a temporary fix for LP: #1968111
 #deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-proposed main restricted

--- a/sources.list
+++ b/sources.list
@@ -1,4 +1,6 @@
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES main restricted
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-updates main restricted
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-security main restricted
+deb [arch=ARCH] http://ppa.launchpad.net/jawn-smith/linux-firmware-raspi/ubuntu SERIES main
+# TODO: remove the PPA
 #deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-proposed main restricted


### PR DESCRIPTION
This is needed for values of os_prefix longer than 8 characters. Currently an issue is being seen where a Raspberry Pi 3b+ is being recognized as a 3b. The newer firmware in the PPA listed allows for longer values of os_prefix.