### PR TITLE
Classic redesign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ ifeq ($(ARCH),arm64)
 MKIMAGE_ARCH := arm64
 else ifeq ($(ARCH),armhf)
 MKIMAGE_ARCH := arm
-else
-$(error Build architecture is not supported)
 endif
 
 # Some trivial comparator macros; please note that these are very simplistic
@@ -85,9 +83,9 @@ endef
 
 default: server
 
-server: firmware uboot boot-script config-server device-trees gadget kernel initrd
+server: firmware uboot boot-script config-server device-trees gadget
 
-desktop: firmware uboot boot-script config-desktop device-trees gadget kernel initrd
+desktop: firmware uboot boot-script config-desktop device-trees gadget
 
 core: firmware uboot boot-script config-core device-trees gadget
 
@@ -97,13 +95,6 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 		cp -a $(STAGEDIR)/usr/lib/linux-firmware-$(FIRMWARE_FLAVOR)/$${file}* \
 			$(DESTDIR)/boot-assets/; \
 	done
-
-kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
-	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
-
-initrd:
-	mkinitramfs -o $(DESTDIR)/boot-assets/initrd.img
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/Makefile
+++ b/Makefile
@@ -221,16 +221,10 @@ device-trees: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 		$(DESTDIR)/boot-assets/overlays/
 
 kernel-initrd:
-	# Add lines to gadget.yaml to handle copying the kernel and initrd
-	echo  "\
-          - source: rootfs:/boot/vmlinuz\n\
-            target: /\n\
-          - source: rootfs:/boot/vmlinuz-$(KERNEL_VERSION)\n\
-            target: /\n\
-          - source: rootfs:/boot/initrd.img\n\
-            target: /\n\
-          - source: rootfs:/boot/initrd.img-$(KERNEL_VERSION)\n\
-            target: /" >> gadget.yaml
+	# Update the kernel version in extra_content.yaml
+	sed \
+		-e "s/@@KERNEL_VERSION@@/$(KERNEL_VERSION)/g" \
+		extra_content.yaml >> gadget.yaml
 
 gadget:
 	mkdir -p $(DESTDIR)/meta

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ ifeq ($(ARCH),arm64)
 MKIMAGE_ARCH := arm64
 else ifeq ($(ARCH),armhf)
 MKIMAGE_ARCH := arm
+else
+$(error Build architecture is not supported)
 endif
 
 # Some trivial comparator macros; please note that these are very simplistic

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,10 @@ ARCH ?= $(shell dpkg --print-architecture)
 SERIES ?= jammy
 
 SOURCES_RESTRICTED := "$(STAGEDIR)/apt/restricted.sources.list"
-SOURCES_MAIN := "$(STAGEDIR)/apt/main.sources.list"
 SERIES_RELEASE := $(firstword $(shell ubuntu-distro-info --release --series=$(SERIES)))
 APT_OPTIONS := \
 	-o APT::Architecture=$(ARCH) \
 	-o Dir::Etc::sourcelist=$(SOURCES_RESTRICTED) \
-	-o Dir::State::status=$(STAGEDIR)/tmp/status
-
-APT_OPTIONS_KERNEL := \
-	-o APT::Architecture=$(ARCH) \
-	-o Dir::Etc::sourcelist=$(SOURCES_MAIN) \
 	-o Dir::State::status=$(STAGEDIR)/tmp/status
 
 ifeq ($(ARCH),arm64)
@@ -116,16 +110,6 @@ $(SOURCES_RESTRICTED):
 		-e "/^deb/ s/\brestricted\b/$(RESTRICTED_COMPONENT)/" \
 		sources.list > $(SOURCES_RESTRICTED)
 	apt-get update $(APT_OPTIONS)
-
-$(SOURCES_MAIN):
-	mkdir -p $(STAGEDIR)/apt
-	mkdir -p $(STAGEDIR)/tmp
-	touch $(STAGEDIR)/tmp/status
-	sed -e "/^deb/ s/\bSERIES/$(SERIES)/" \
-		-e "/^deb/ s/\bARCH\b/$(ARCH)/" \
-		-e "/^deb/ s/\bmain\b/main/" \
-		sources.list > $(SOURCES_MAIN)
-	apt-get update $(APT_OPTIONS_KERNEL)
 
 # XXX: This should be removed (along with the dependencies in classic/core)
 # when uboot is removed entirely from the boot partition. At present, it is
@@ -235,9 +219,9 @@ device-trees: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 		-name "*.dtbo" -o -name "overlay_map.dtb") \
 		$(DESTDIR)/boot-assets/overlays/
 
-kernel-initrd: $(SOURCES_MAIN)
+kernel-initrd: $(SOURCES_RESTRICTED)
 	# Update the kernel version in extra_content.yaml
-	$(eval KERNEL_VERSION := $(shell apt-cache $(APT_OPTIONS_KERNEL) policy linux-raspi | grep Candidate | cut -d " " -f 4 | cut -d "." -f 1-4 | sed 's/\(.*\)\./\1-/'))
+	$(eval KERNEL_VERSION := $(shell apt-cache $(APT_OPTIONS) policy linux-raspi | grep Candidate | cut -d " " -f 4 | cut -d "." -f 1-4 | sed 's/\(.*\)\./\1-/'))
 	sed \
 		-e "s/@@KERNEL_VERSION@@/$(KERNEL_VERSION)/g" \
 		extra_content.yaml >> gadget.yaml

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ FIRMWARE_FLAVOR := $(if $(call ge,$(SERIES_RELEASE),22.04),raspi,raspi2)
 KERNEL_VERSION := $(shell linux-version list | grep $(KERNEL_FLAVOR) | linux-version sort | tail -1)
 
 # Download the latest version of package $1 for architecture $(ARCH), unpacking
-#
 # it into $(STAGEDIR). If you rely on this macro, your recipe must also rely on
 # the $(SOURCES_RESTRICTED) target. For example, the following invocation will
 # download the latest version of u-boot-rpi for armhf, and unpack it under

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
 
 initrd:
 	mkinitramfs -o $(DESTDIR)/boot-assets/initrd.img

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ device-trees: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 kernel-initrd: $(SOURCES_MAIN)
 	# Update the kernel version in extra_content.yaml
-	$(eval KERNEL_VERSION := $(shell apt-cache $(APT_OPTIONS_KERNEL) policy linux-raspi | grep Candidate | cut -d " " -f 4 | cut -d "." -f 1-4))
+	$(eval KERNEL_VERSION := $(shell apt-cache $(APT_OPTIONS_KERNEL) policy linux-raspi | grep Candidate | cut -d " " -f 4 | cut -d "." -f 1-4 | sed 's/\(.*\)\./\1-/'))
 	sed \
 		-e "s/@@KERNEL_VERSION@@/$(KERNEL_VERSION)/g" \
 		extra_content.yaml >> gadget.yaml

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ endef
 
 default: server
 
-server: firmware uboot boot-script config-server device-trees gadget kernel
+server: firmware uboot boot-script config-server device-trees gadget kernel initrd
 
-desktop: firmware uboot boot-script config-desktop device-trees gadget kernel
+desktop: firmware uboot boot-script config-desktop device-trees gadget kernel initrd
 
 core: firmware uboot boot-script config-core device-trees gadget
 
@@ -100,7 +100,10 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
+
+initrd:
+	mkinitramfs -o $(DESTDIR)/boot-assets/initrd.img
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ endef
 
 default: server
 
-server: firmware uboot boot-script config-server device-trees gadget
+server: firmware uboot boot-script config-server device-trees gadget kernel
 
-desktop: firmware uboot boot-script config-desktop device-trees gadget
+desktop: firmware uboot boot-script config-desktop device-trees gadget kernel
 
 core: firmware uboot boot-script config-core device-trees gadget
 
@@ -97,6 +97,10 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 		cp -a $(STAGEDIR)/usr/lib/linux-firmware-$(FIRMWARE_FLAVOR)/$${file}* \
 			$(DESTDIR)/boot-assets/; \
 	done
+
+kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
+	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 kernel: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 	$(call stage_package,linux-image-[0-9]*-$(KERNEL_FLAVOR))
-	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets
+	cp -a $(STAGEDIR)/boot/vmlinuz* $(DESTDIR)/boot-assets/vmlinuz
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse

--- a/extra_content.yaml
+++ b/extra_content.yaml
@@ -1,0 +1,8 @@
+          - source: rootfs:/boot/vmlinuz
+            target: /
+          - source: rootfs:/boot/vmlinuz-@@KERNEL_VERSION@@
+            target: /
+          - source: rootfs:/boot/initrd.img
+            target: /
+          - source: rootfs:/boot/initrd.img-@@KERNEL_VERSION@@
+            target: /

--- a/extra_content.yaml
+++ b/extra_content.yaml
@@ -1,8 +1,8 @@
           - source: rootfs:/boot/vmlinuz
             target: /
-          - source: rootfs:/boot/vmlinuz-@@KERNEL_VERSION@@
+          - source: rootfs:/boot/vmlinuz-@@KERNEL_VERSION@@-raspi
             target: /
           - source: rootfs:/boot/initrd.img
             target: /
-          - source: rootfs:/boot/initrd.img-@@KERNEL_VERSION@@
+          - source: rootfs:/boot/initrd.img-@@KERNEL_VERSION@@-raspi
             target: /

--- a/extra_content.yaml
+++ b/extra_content.yaml
@@ -1,8 +1,4 @@
           - source: rootfs:/boot/vmlinuz
             target: /
-          - source: rootfs:/boot/vmlinuz-@@KERNEL_VERSION@@-raspi
-            target: /
           - source: rootfs:/boot/initrd.img
-            target: /
-          - source: rootfs:/boot/initrd.img-@@KERNEL_VERSION@@-raspi
             target: /

--- a/extra_content.yaml
+++ b/extra_content.yaml
@@ -1,4 +1,4 @@
-          - source: rootfs:/boot/vmlinuz
-            target: /
-          - source: rootfs:/boot/initrd.img
-            target: /
+          - source: rootfs:/boot/vmlinuz-@@KERNEL_VERSION@@-raspi
+            target: vmlinuz
+          - source: rootfs:/boot/initrd.img-@@KERNEL_VERSION@@-raspi
+            target: initrd.img

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -11,7 +11,3 @@ volumes:
         content:
           - source: install/boot-assets/
             target: /
-          - source: rootfs:/boot/vmlinuz*
-            target: vmlinuz
-          - source: rootfs:/boot/initrd*
-            target: initrd.img

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -9,5 +9,5 @@ volumes:
         filesystem-label: system-boot
         size: 512M
         content:
-          - source: boot-assets/
+          - source: install/boot-assets/
             target: /

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -7,7 +7,7 @@ volumes:
       - type: 0C
         filesystem: vfat
         filesystem-label: system-boot
-        size: 384M
+        size: 512M
         content:
           - source: boot-assets/
             target: /

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -7,6 +7,7 @@ volumes:
       - type: 0C
         filesystem: vfat
         filesystem-label: system-boot
+        role: system-boot
         size: 512M
         content:
           - source: install/boot-assets/

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -7,7 +7,7 @@ volumes:
       - type: 0C
         filesystem: vfat
         filesystem-label: system-boot
-        size: 256M
+        size: 384M
         content:
           - source: boot-assets/
             target: /

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -11,3 +11,7 @@ volumes:
         content:
           - source: install/boot-assets/
             target: /
+          - source: rootfs:/boot/vmlinuz
+            target: vmlinuz
+          - source: rootfs:/boot/initrd.img
+            target: initrd.img

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -11,7 +11,7 @@ volumes:
         content:
           - source: install/boot-assets/
             target: /
-          - source: rootfs:/boot/vmlinuz
+          - source: rootfs:/boot/vmlinuz*
             target: vmlinuz
-          - source: rootfs:/boot/initrd.img
+          - source: rootfs:/boot/initrd*
             target: initrd.img


### PR DESCRIPTION
This is done to source the initrd and kernel from the rootfs, removing duplication between the gadget and flash-kernel. This will only work with ubuntu-image >= 3.0.