### PR TITLE
Updated for core22-desktop

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -7,7 +7,7 @@ volumes:
         role: system-seed
         filesystem: vfat
         type: 0C
-        size: 1200M
+        size: 3500M
         content:
           - source: $kernel:dtbs/dtbs/broadcom/
             target: /
@@ -38,3 +38,45 @@ volumes:
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         # XXX: make auto-grow to partition
         size: 1500M
+
+defaults:
+  system:
+    experimental.user-daemons: true
+    experimental.dbus-activation: true
+    refresh.retain: 2
+    service.ssh.listen-address: 127.0.0.1
+    swap.size: 1G
+
+# Connect ubuntu-desktop-session
+connections:
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:account-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:avahi-control
+    slot: dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll:avahi-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:desktop-launch
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:hardware-observe
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:home
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:hostname-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:locale-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:login-session-observe
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:login-session-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:mount-observe
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:network-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:network-observe
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:polkit-agent
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:process-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:shutdown
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:snapd-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:system-observe
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:shell-config-files
+    slot: system:system-files
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:time-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:timeserver-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:timezone-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:upower-observe
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:network-manager
+    slot: RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy:service
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:bluez
+    slot: JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS:service
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:bluetooth-control
+  - plug: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN:cups-control
+    slot: m1eQacDdXCthEwWQrESei3Zao3d5gfJF:cups-control

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: pi
+name: pi-desktop
 version: 22-2
 summary: Raspberry Pi gadget
 description: |
@@ -6,7 +6,8 @@ description: |
   This gadget snap supports the Raspberry Pi 2B, 3B, 3A+, 3B+, 4B, Compute
   Module 3, and the Compute Module 3+ universally.
 type: gadget
-base: core22
+build-base: core22
+base: core22-desktop
 assumes: [kernel-assets]
 architectures:
   - build-on: [amd64, arm64]


### PR DESCRIPTION
  * Renamed snap to pi-desktop
  * Increased size to accomodate seeded snaps
  * Match default settings from the pc-desktop gadget
  * Make necessary connections