### PR TITLE
Copy gadget.yaml in meta dir to respect convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,8 @@ device-trees: local-apt $(DESTDIR)/boot-assets
 
 gadget:
 	$(call fill_template,gadget.yaml.in,gadget.yaml)
+	mkdir -p $(DESTDIR)/meta
+	cp gadget.yaml $(DESTDIR)/meta/
 
 clean:
 	-rm -rf $(DESTDIR) $(STAGEDIR) gadget.yaml


### PR DESCRIPTION
As stated in https://ubuntu.com/core/docs/gadget-snaps a built gadget is supposed to have the `gadget.yaml` file under the `meta` dir. ubuntu-image is expecting this convention to be respected to fetch the `gadget.yaml` file.

This PR make sure the `gadtet.yaml` file is copied in the `meta` directory.