### PR TITLE
Remove reference to DESTDIR in gadget.yaml source content

### DIFF
--- a/gadget.yaml.in
+++ b/gadget.yaml.in
@@ -10,7 +10,7 @@ volumes:
         role: system-boot
         size: 512M
         content:
-          - source: @@DESTDIR@@/boot-assets/
+          - source: boot-assets/
             target: /
           - source: rootfs:/boot/vmlinuz-@@KERNEL_VERSION@@
             target: vmlinuz


### PR DESCRIPTION
Based on the gadget snap documentation and other versions of gadget snap, the paths used in the content section should not suppose the gadget.yaml file is in the parent directory of the assets. This directory is given as another parameter to the tool handling the gadget (snapd, ubuntu-image, etc.). So we remove the reference to the DESTDIR since this directory will be the root dir given to the tool in most cases.

This is related to https://github.com/canonical/ubuntu-image/pull/175