### PR TITLE
snapcraft: add core24 builds for arm64

### DIFF
--- a/helpers/cross-sources.list
+++ b/helpers/cross-sources.list
@@ -1,12 +1,12 @@
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal main universe multiverse restricted
-deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal main universe multiverse restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main universe multiverse restricted
-deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main universe multiverse restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main universe multiverse restricted
-deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main universe multiverse restricted
-#deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-proposed main universe multiverse restricted
-#deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-proposed main universe multiverse restricted
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe multiverse restricted
+deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe multiverse restricted
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe multiverse restricted
+deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe multiverse restricted
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe multiverse restricted
+deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe multiverse restricted
+#deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-proposed main universe multiverse restricted
+#deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-proposed main universe multiverse restricted
 
 # snappy-dev image PPA
-deb [arch=armhf,arm64] http://ppa.launchpad.net/snappy-dev/image/ubuntu focal main
-deb-src [arch=armhf,arm64] http://ppa.launchpad.net/snappy-dev/image/ubuntu focal main
+deb [arch=armhf,arm64] http://ppa.launchpad.net/snappy-dev/image/ubuntu noble main
+deb-src [arch=armhf,arm64] http://ppa.launchpad.net/snappy-dev/image/ubuntu noble main

--- a/helpers/cross-sources.list
+++ b/helpers/cross-sources.list
@@ -1,12 +1,12 @@
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe multiverse restricted
-deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe multiverse restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe multiverse restricted
-deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe multiverse restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe multiverse restricted
-deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe multiverse restricted
-#deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-proposed main universe multiverse restricted
-#deb-src [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-proposed main universe multiverse restricted
+deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES main universe multiverse restricted
+deb-src [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES main universe multiverse restricted
+deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-updates main universe multiverse restricted
+deb-src [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-updates main universe multiverse restricted
+deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-security main universe multiverse restricted
+deb-src [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-security main universe multiverse restricted
+#deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-proposed main universe multiverse restricted
+#deb-src [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-proposed main universe multiverse restricted
 
 # snappy-dev image PPA
-deb [arch=armhf,arm64] http://ppa.launchpad.net/snappy-dev/image/ubuntu noble main
-deb-src [arch=armhf,arm64] http://ppa.launchpad.net/snappy-dev/image/ubuntu noble main
+deb [arch=ARCH] http://ppa.launchpad.net/snappy-dev/image/ubuntu SERIES main
+deb-src [arch=ARCH] http://ppa.launchpad.net/snappy-dev/image/ubuntu SERIES main

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,8 +12,6 @@ assumes: [kernel-assets]
 architectures:
   - build-on: [amd64, arm64]
     build-for: [arm64]
-  - build-on: [amd64, armhf]
-    build-for: [armhf]
 
 package-repositories:
   - type: apt
@@ -28,11 +26,8 @@ parts:
     override-build: |
       set -x
       
-      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
-        BUILD_ARCH_TRIPLET=aarch64-linux-gnu
-      else
-        BUILD_ARCH_TRIPLET=arm-linux-gnueabihf
-      fi
+      # we only support arm64 for 24 for pi
+      BUILD_ARCH_TRIPLET=aarch64-linux-gnu
       
       # but only use the cross-compiling sources when actually cross compiling
       # as otherwise its just safer to use the build environment - it offers
@@ -43,6 +38,7 @@ parts:
       
       make -C $SNAPCRAFT_PART_SRC core \
         DESTDIR=${SNAPCRAFT_PART_INSTALL} \
+        SERIES=noble \
         ARCH="$(dpkg-architecture -t $BUILD_ARCH_TRIPLET -q DEB_HOST_ARCH)" \
         ${OPTIONAL_ARGS:-}
     prime:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,6 +12,8 @@ assumes: [kernel-assets]
 architectures:
   - build-on: [amd64, arm64]
     build-for: [arm64]
+  - build-on: [amd64, armhf]
+    build-for: [armhf]
 
 package-repositories:
   - type: apt
@@ -25,15 +27,20 @@ parts:
     source: .
     override-build: |
       set -x
-      # unconditionally set the arch-triplet since this snapcraft.yaml will 
-      # always be used to produce an armhf snap
-      BUILD_ARCH_TRIPLET=aarch64-linux-gnu
+      
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        BUILD_ARCH_TRIPLET=aarch64-linux-gnu
+      else
+        BUILD_ARCH_TRIPLET=arm-linux-gnueabihf
+      fi
+      
       # but only use the cross-compiling sources when actually cross compiling
       # as otherwise its just safer to use the build environment - it offers
       # much more flexibility.
       if [ "$SNAPCRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ] || [ -z "$SNAPCRAFT_ARCH_TRIPLET" ]; then
         OPTIONAL_ARGS="SERIES_HOST=\"focal\" SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
       fi
+      
       make -C $SNAPCRAFT_PART_SRC core \
         DESTDIR=${SNAPCRAFT_PART_INSTALL} \
         ARCH="$(dpkg-architecture -t $BUILD_ARCH_TRIPLET -q DEB_HOST_ARCH)" \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,12 +1,13 @@
 name: pi
-version: 22-2
+version: 24-1
 summary: Raspberry Pi gadget
 description: |
   Support files for booting Raspberry Pi.
   This gadget snap supports the Raspberry Pi 2B, 3B, 3A+, 3B+, 4B, Compute
   Module 3, and the Compute Module 3+ universally.
 type: gadget
-base: core22
+base: core24
+build-base: devel
 assumes: [kernel-assets]
 architectures:
   - build-on: [amd64, arm64]
@@ -17,7 +18,7 @@ package-repositories:
     ppa: snappy-dev/image
 
 confinement: strict
-grade: stable
+grade: devel
 parts:
   gadget:
     plugin: nil

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,18 +28,23 @@ parts:
       
       # we only support arm64 for 24 for pi
       BUILD_ARCH_TRIPLET=aarch64-linux-gnu
+      BUILD_SERIES=noble
+      BUILD_ARCH="$(dpkg-architecture -t $BUILD_ARCH_TRIPLET -q DEB_HOST_ARCH)"
       
       # but only use the cross-compiling sources when actually cross compiling
       # as otherwise its just safer to use the build environment - it offers
       # much more flexibility.
       if [ "$SNAPCRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ] || [ -z "$SNAPCRAFT_ARCH_TRIPLET" ]; then
-        OPTIONAL_ARGS="SERIES_HOST=\"focal\" SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
+        sed -i "/^deb/ s/\bSERIES/$(BUILD_SERIES)/" \
+            -i "/^deb/ s/\bARCH\b/$(BUILD_ARCH)/" \
+            ./helpers/cross-sources.list
+        OPTIONAL_ARGS="SERIES_HOST=\"$BUILD_SERIES\" SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
       fi
       
       make -C $SNAPCRAFT_PART_SRC core \
         DESTDIR=${SNAPCRAFT_PART_INSTALL} \
-        SERIES=noble \
-        ARCH="$(dpkg-architecture -t $BUILD_ARCH_TRIPLET -q DEB_HOST_ARCH)" \
+        SERIES="$BUILD_SERIES" \
+        ARCH="$BUILD_ARCH" \
         ${OPTIONAL_ARGS:-}
     prime:
       - boot-assets/*

--- a/sources.list
+++ b/sources.list
@@ -1,6 +1,4 @@
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES main restricted
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-updates main restricted
 deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-security main restricted
-deb [arch=ARCH] http://ppa.launchpad.net/jawn-smith/linux-firmware-raspi/ubuntu SERIES main
-# TODO: remove the PPA above. It is a temporary fix for LP: #1968111
-#deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-proposed main restricted
+deb [arch=ARCH] http://ports.ubuntu.com/ubuntu-ports/ SERIES-proposed main restricted


### PR DESCRIPTION
Pi gadgets for Ubuntu Core 24 - Goal with this is to support both armhf and arm64 from the same branch as changes between those two are minimal. (Did I miss any changes?)

I currently have them in build-base: devel as the base is not stable yet. Do we wait for this or change this in a followup PR once the base goes stable?
