### PR TITLE
snapcraft: fix sed commands and replace more deprecated snapcraft vars.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ firmware: $(SOURCES_RESTRICTED) $(DESTDIR)/boot-assets
 
 # All the default components got moved to main or restricted in groovy. Prior
 # to this (focal and before) certain bits were (are) in universe or multiverse
+# TODO: remove the '|| true' once noble 24.04 is stable
 RESTRICTED_COMPONENT := $(if $(call le,$(SERIES_RELEASE),20.04),universe multiverse,restricted)
 $(SOURCES_RESTRICTED):
 	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv C176CB99A28EA6D8 # TODO: remove this

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(SOURCES_RESTRICTED):
 		-e "/^deb/ s/\bARCH\b/$(ARCH)/" \
 		-e "/^deb/ s/\brestricted\b/$(RESTRICTED_COMPONENT)/" \
 		sources.list > $(SOURCES_RESTRICTED)
-	apt-get update $(APT_OPTIONS)
+	apt-get update $(APT_OPTIONS) || true
 
 # XXX: This should be removed (along with the dependencies in classic/core)
 # when uboot is removed entirely from the boot partition. At present, it is

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,14 +39,13 @@ parts:
       # as otherwise its just safer to use the build environment - it offers
       # much more flexibility.
       if [ "$CRAFT_ARCH_TRIPLET_BUILD_ON" = "x86_64-linux-gnu" ] || [ -z "$CRAFT_ARCH_TRIPLET_BUILD_ON" ]; then
-        sed -i "/^deb/ s/\bSERIES/$BUILD_SERIES/" \
-            -i "/^deb/ s/\bARCH\b/$BUILD_ARCH/" \
-            ./helpers/cross-sources.list
+        sed -i "/^deb/s/\bSERIES/$BUILD_SERIES/" ./helpers/cross-sources.list
+        sed -i "/^deb/s/\bARCH\b/$BUILD_ARCH/" ./helpers/cross-sources.list
         OPTIONAL_ARGS="SERIES_HOST=\"$BUILD_SERIES\" SOURCES_HOST=\"./helpers/cross-sources.list\" SOURCES_D_HOST=\"./helpers\""
       fi
       
-      make -C $SNAPCRAFT_PART_SRC core \
-        DESTDIR=${SNAPCRAFT_PART_INSTALL} \
+      make -C $CRAFT_PART_SRC core \
+        DESTDIR=${CRAFT_PART_INSTALL} \
         SERIES="$BUILD_SERIES" \
         ARCH="$BUILD_ARCH" \
         ${OPTIONAL_ARGS:-}


### PR DESCRIPTION
Also ignore that apt-get update might get a couple of misses due to PPAs not being reached.