### PR TITLE
snapcraft: add gnupg/dirmngr packages as a build package for LP build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -57,6 +57,7 @@ parts:
       - dpkg-dev
       - make
       - gnupg
+      - dirmngr
 
 slots:
   bcm-gpio-0:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -56,6 +56,7 @@ parts:
       - lsb-release
       - dpkg-dev
       - make
+      - gnupg
 
 slots:
   bcm-gpio-0:


### PR DESCRIPTION
Attempt at fixing the LP build, which fails when receiving gpg keys. 