### PR TITLE
Set console=tty1 for Ubuntu Core

### DIFF
--- a/configs/cmdline.txt-core
+++ b/configs/cmdline.txt-core
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 rng_core.default_quality=700 vt.handoff=2 quiet splash
+dwc_otg.lpm_enable=0 console=tty1 rng_core.default_quality=700 vt.handoff=2 quiet splash


### PR DESCRIPTION
Otherwise console-conf won't show up.