### PR TITLE
Use KMS on 24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ CORE_CFG := \
 	common \
 	$(if $(call ge,$(SERIES_RELEASE),22.04),serial-console,) \
 	$(if $(call ge,$(SERIES_RELEASE),20.04),cm4-support,) \
-	fkms \
+	kms \
 	$(if $(call lt,$(SERIES_RELEASE),20.04),heartbeat-active,heartbeat-inactive) \
 	$(ARCH)
 CORE_CMD := \


### PR DESCRIPTION
The fkms overlay has not been supported upstream since buster, and is not supported at all on the Pi 5. Switch to the kms overlay instead. This will require a re-spin of the image at some point in the future.

Fixes: #115