### PR TITLE
Add serial slots for ttyAMA[1-5]

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -233,6 +233,9 @@ slots:
   ama4-serial:
     interface: serial-port
     path: /dev/ttyAMA4
+  ama5-serial:
+    interface: serial-port
+    path: /dev/ttyAMA5
   serial0:
     interface: serial-port
     path: /dev/ttyS0

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -221,6 +221,18 @@ slots:
   bt-serial:
     interface: serial-port
     path: /dev/ttyAMA0
+  ama1-serial:
+    interface: serial-port
+    path: /dev/ttyAMA1
+  ama2-serial:
+    interface: serial-port
+    path: /dev/ttyAMA2
+  ama3-serial:
+    interface: serial-port
+    path: /dev/ttyAMA3
+  ama4-serial:
+    interface: serial-port
+    path: /dev/ttyAMA4
   serial0:
     interface: serial-port
     path: /dev/ttyS0


### PR DESCRIPTION
There's already bt-serial mapped to /dev/ttyAMA0, but rpi 4 embeds ttyAMA[1-5] as well. It's currently not accessible as far as we're aware of in any way in strictly confined snaps. 

There's also this for additional context: https://forum.snapcraft.io/t/rs485-support-in-pi-gadget-snap-for-raspberry-pi-cm4/32043

The PR hasn't been tested. If anything else is needed, let me know. 