### PR TITLE
snapcraft.yaml: remove gpio 7+8 slots as they are by default in use by the SPI0 device

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,12 +80,15 @@ slots:
   bcm-gpio-6:
     interface: gpio
     number: 6
-  bcm-gpio-7:
-    interface: gpio
-    number: 7
-  bcm-gpio-8:
-    interface: gpio
-    number: 8
+# GPIO 7 and 8 are by default in use for the SPI0 device
+# and dtparam=spi=on in config.txt-common must be changed
+# for those to be available.
+#  bcm-gpio-7:
+#    interface: gpio
+#    number: 7
+#  bcm-gpio-8:
+#    interface: gpio
+#    number: 8
   bcm-gpio-9:
     interface: gpio
     number: 9


### PR DESCRIPTION
To use GPIO7+8 one must create their own gadget and configure the pi to release those pins by turning the SPI0 off.


See the bug report here:
https://bugs.launchpad.net/snapd/+bug/2106624