### PR TITLE
Create swap-file for desktop

### DIFF
--- a/configs/questing-arm64-desktop/user-data
+++ b/configs/questing-arm64-desktop/user-data
@@ -10,6 +10,14 @@
 # to customize the rest of the configuration as desired.
 users: []
 
+# Create a 1GB swap file. Customize this if you wish to create a larger (or
+# smaller) swap file, or comment it out to disable its creation
+swap:
+  filename: /swapfile
+  size: 1G
+  #size: auto
+  #maxsize: 4G
+
 # Some examples of customization are provided in comments below; please refer
 # to the cloud-init documentation for full details of the configuration format:
 #


### PR DESCRIPTION
The mkswap.service we used for this is failing on the questing dailies. It would be better to remove that and simply rely on cloud-init instead which is already capable of this, and provides more flexibility for users to customize their swap settings.

[LP: #2116275](https://bugs.launchpad.net/ubuntu/+source/ubuntu-raspi-settings/+bug/2116275)