### PR TITLE
Enable hardware watchdog in questing

### DIFF
--- a/configs/questing-arm64-desktop/config.txt
+++ b/configs/questing-arm64-desktop/config.txt
@@ -16,6 +16,7 @@ initramfs initrd.img followkernel
 dtparam=audio=on
 dtparam=i2c_arm=on
 dtparam=spi=on
+dtparam=watchdog=on
 
 # Comment out the following line if the edges of the desktop appear outside
 # the edges of your display

--- a/configs/questing-arm64-server/config.txt
+++ b/configs/questing-arm64-server/config.txt
@@ -16,6 +16,7 @@ initramfs initrd.img followkernel
 dtparam=audio=on
 dtparam=i2c_arm=on
 dtparam=spi=on
+dtparam=watchdog=on
 
 # Comment out the following line if the edges of the desktop appear outside
 # the edges of your display


### PR DESCRIPTION
As part of the A/B boot facility introduced in questing, we need the hardware watchdog enabled (or a failed boot requires manual power off/on to fallback). The flash-kernel component was already updated to include this during migration, but this also needs adding to fresh installs (which will not undergo migration and therefore would never enable it otherwise).

[LP: #2120177](https://bugs.launchpad.net/ubuntu/+source/flash-kernel/+bug/2120177)