### PR TITLE
Remove the deprecated z3fold pool allocator

### DIFF
--- a/configs/questing-arm64-desktop/current/cmdline.txt
+++ b/configs/questing-arm64-desktop/current/cmdline.txt
@@ -1,1 +1,1 @@
-zswap.enabled=1 zswap.zpool=z3fold zswap.compressor=zstd multipath=off dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 rootwait fixrtc quiet splash
+zswap.enabled=1 zswap.compressor=zstd multipath=off dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 rootwait fixrtc quiet splash


### PR DESCRIPTION
This is a minor change in that z3fold no longer exists in the (proposed) questing kernel, so the boot falls back to zsmalloc (the new default) anyway. However, it does leave an error in the kernel log on every boot, which we should avoid ideally.

The corresponding change for initramfs-tools' modules list has already been published in ubuntu-raspi-settings.

[LP: #2125496](https://bugs.launchpad.net/ubuntu/+source/ubuntu-raspi-settings/+bug/2125496)