### PR TITLE
Ensure corrupted initramfs also falls back in A/B boot

### DIFF
--- a/configs/questing-arm64-desktop/current/cmdline.txt
+++ b/configs/questing-arm64-desktop/current/cmdline.txt
@@ -1,1 +1,1 @@
-zswap.enabled=1 zswap.zpool=z3fold zswap.compressor=zstd multipath=off dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 rootwait fixrtc quiet splash
+zswap.enabled=1 zswap.zpool=z3fold zswap.compressor=zstd multipath=off dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 panic=10 rootwait fixrtc quiet splash

--- a/configs/questing-arm64-server/current/cmdline.txt
+++ b/configs/questing-arm64-server/current/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 multipath=off dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 rootwait fixrtc
+console=serial0,115200 multipath=off dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 panic=10 rootwait fixrtc


### PR DESCRIPTION
During further ISO tests with the proposed kernel in questing, we discovered that the hardware watchdog is insufficient in cases where the kernel is still running but has panicked because (for example) the initramfs is corrupt.

Adds panic=10 to the default kernel configuration to ensure that in this circumstance, the machine still resets providing an opportunity for the bootloader to fallback to the "known good" configuration.