### PR TITLE
Make the archive URL vary depending on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ RESTRICTED_COMPONENT := $(if $(call le,$(SERIES_RELEASE),20.04),universe multive
 # From questing onwards, the kernel, initrd, device-trees, and overlays all
 # live under a "current/" prefix by default
 OS_PREFIX := $(if $(call ge,$(SERIES_RELEASE),25.10),current/,)
+# From resolute, the main archive is now used instead of ports (eventually this
+# change will make its way back to earlier LTS')
+ARCHIVE_URL := http://$(if $(call ge,$(SERIES_RELEASE),26.04),archive.ubuntu.com/ubuntu,ports.ubuntu.com/ubuntu-ports)/
 
 
 # Download the latest version of package $1 for architecture $(ARCH), unpacking
@@ -205,7 +208,7 @@ clean:
 local-apt:
 	chdist -d $(STAGEDIR) -a $(ARCH) \
 		create gadget \
-		http://ports.ubuntu.com/ubuntu-ports/ \
+		$(ARCHIVE_URL) \
 		$(SERIES) \
 		main $(RESTRICTED_COMPONENT)
 	awk '{ \


### PR DESCRIPTION
As of resolute the main archive is to be used (rather than ports.ubuntu.com). Earlier LTS' will migrate at some point (which will simply mean adjusting the SERIES_RELEASE comparison in the new definition).